### PR TITLE
Fix dynamic module loading and build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Terminal-style portfolio with Tailwind, JavaScript & modular UI.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "esbuild src/main.js --bundle --outfile=dist/main.js --minify && cp -r public/* dist/"
+    "test": "node --test",
+    "build": "esbuild src/**/*.js --bundle --outdir=dist --minify && cp -r public/* dist/"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "esbuild": "^0.25.5"
   }

--- a/src/TabNavigator.js
+++ b/src/TabNavigator.js
@@ -27,7 +27,7 @@ export function initSidebar(onSelect) {
     btn.dataset.tabId = t.id;
     btn.className =
       'w-full h-12 flex items-center justify-center border-l-4 border-transparent glow-hover transition ease-in-out duration-300';
-    btn.innerHTML = `<img src="../public/assets/icons/${t.icon}.svg" class="w-5 h-5" alt="${t.id}">`;
+    btn.innerHTML = `<img src="./assets/icons/${t.icon}.svg" class="w-5 h-5" alt="${t.id}">`;
     btn.addEventListener('click', () => {
       onSelectCb(t.id);
       if (window.innerWidth < 640) sidebar.classList.add('hidden');

--- a/src/tabContent/TabLoader.js
+++ b/src/tabContent/TabLoader.js
@@ -1,21 +1,8 @@
-const routes = {
-  'home.boot': './home.boot.js',
-  'about': './about.js',
-  'skills': './skills.js',
-  'projects.vue': './projects.vue.js',
-  'certs': './certs.js',
-  'resume': './resume.js',
-  'system.ai': './system.ai.js',
-  'chat.terminal': './chat.terminal.js',
-  'visitor.log': './visitor.log.js',
-  'config.sys': './config.sys.js',
-  'sandbox.dev': './sandbox.dev.js',
-  'vault.ads': './vault.ads.js',
-  'env.sys': './env.sys.js'
-};
-
-export async function loadTab(id) {
-  const path = routes[id];
-  if (!path) return null;
-  return import(path);
+export async function loadTab(tab) {
+  try {
+    return await import(`./${tab}.js`);
+  } catch (e) {
+    document.getElementById('app').innerHTML = `Tab ${tab} not found.`;
+    return null;
+  }
 }

--- a/tests/tabLoader.test.mjs
+++ b/tests/tabLoader.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { loadTab } from '../src/tabContent/TabLoader.js';
+
+test('loadTab shows fallback for missing tab', async () => {
+  let content = '';
+  global.document = {
+    getElementById() {
+      return {
+        get innerHTML() { return content; },
+        set innerHTML(v) { content = v; }
+      };
+    }
+  };
+  const mod = await loadTab('no-such-tab');
+  assert.equal(mod, null);
+  assert.equal(content, 'Tab no-such-tab not found.');
+});


### PR DESCRIPTION
## Summary
- update build command to bundle all JS files
- fix icon paths in `TabNavigator`
- simplify `TabLoader` and add fallback when a tab is missing
- add simple `node:test` script and TabLoader test

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68543aa9487c8331917891e4beec73ab