### PR TITLE
Fix build paths for Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test",
-    "build": "esbuild src/main.js --bundle --outfile=dist/main.js --minify && cp -r public/* dist/ && mkdir -p dist/tabContent && cp src/tabContent/*.js dist/tabContent/"
+    "build": "esbuild src/**/*.js --bundle --outdir=dist --minify && cp -r public/* dist/ && cp -r styles dist/"
   },
   "keywords": [],
   "author": "",

--- a/public/index.html
+++ b/public/index.html
@@ -14,14 +14,14 @@
   <meta property="og:description" content="Explore my projects in a code editor simulation." />
   <link rel="icon" href="favicon.ico">
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="../styles/index.css">
+  <link rel="stylesheet" href="./styles/index.css">
   <script src="https://cdn.jsdelivr.net/npm/animejs@3.2.1/lib/anime.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.16"></script>
   <script src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.7/dist/tippy-bundle.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
-  <script type="module" src="main.js"></script>
+  <script type="module" src="./main.js"></script>
 </head>
 <body class="bg-base text-base font-mono flex">
   <button id="sidebar-toggle" class="sm:hidden p-2 text-white fixed top-2 left-2 z-10 bg-gray-800 rounded">&#9776;</button>


### PR DESCRIPTION
## Summary
- bundle all src JS files to `dist` with esbuild
- copy static files and styles into `dist`
- point HTML to bundled `main.js` and local stylesheet

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68544dd654688331b9b9ba1e8538d64a